### PR TITLE
Add missing FindLookingTowards check in regiment NextTurn

### DIFF
--- a/main/midnight/Classes/tme/scenario/item_regiment.cpp
+++ b/main/midnight/Classes/tme/scenario/item_regiment.cpp
@@ -134,7 +134,7 @@ namespace tme {
 			// ie: someone else is in the next location
 			if ( !IsFlags(rf_direct) ) {
 				for (dir=DR_NORTH; dir<=DR_NORTHWEST; dir=(mxdir_t)((int)dir+1))	{
-					targetlocation = Location()+dir;
+					targetlocation = mx->scenario->FindLookingTowards(Location(),dir);
 					if ( mx->gamemap->IsLocationSpecial(targetlocation) ) {
 						bFoundLocation=TRUE;
 						break;


### PR DESCRIPTION
When a regiment is checking the surrounding locations for something interesting, the FindLookingTowards call seems to have been removed. This means the regiment is only looking at the surrounding location and not up to 3 locations away.