### PR TITLE
Fix detection of upgrade to take into account full version + maintena…

### DIFF
--- a/main/midnight/src/system/moonring.h
+++ b/main/midnight/src/system/moonring.h
@@ -125,6 +125,8 @@ public:
     // Version
 #if defined(_USE_VERSION_CHECK_)
     void getVersion(const GetVersionCallback& callback);
+    static std::tuple<int, int, int> getVersionBreakup(std::string fullVersion);
+
 #endif
     
 protected:

--- a/main/midnight/src/tme/base/mxinterface.cpp
+++ b/main/midnight/src/tme/base/mxinterface.cpp
@@ -21,6 +21,7 @@
 #endif
 #include <string.h>
 #include <string>
+#include <memory>
 
 
 namespace tme {


### PR DESCRIPTION
…nce (e.g. 2.0.5.43) instead of just build number

Issue was that code was looking only at build number. So new version 2.0.5 build 1 would detect available 2.0.4 build 43 as an upgrade available. Fixed to take into account full version + build number.