### PR TITLE
#178 Remap DDR character flags and add tests

### DIFF
--- a/main/midnight/src/library/inc/cflags.h
+++ b/main/midnight/src/library/inc/cflags.h
@@ -53,12 +53,13 @@ public:
         if ( ar.IsStoring() ) { ar << m_flags ; }else{ar >> m_flags ;}
         return ar;
     }
-    MXINLINE flags()                             { m_flags = 0 ; }
-    MXINLINE void Set ( T f )                        { m_flags |= f ; }
-    MXINLINE void Reset ( T f )                      { m_flags &= ~f ; }
-    MXINLINE void Toggle ( T f )                     { if ( Is(f) ) Reset(f); else Set(f); }
-    MXINLINE bool Is ( T f) const                    { return m_flags&f ? TRUE : FALSE  ; }
-    MXINLINE operator T() const                      { return m_flags; }
+    MXINLINE flags(T value)                             { m_flags = value;}
+    MXINLINE flags()                                    { m_flags = 0 ; }
+    MXINLINE void Set ( T f )                           { m_flags |= f ; }
+    MXINLINE void Reset ( T f )                         { m_flags &= ~f ; }
+    MXINLINE void Toggle ( T f )                        { if ( Is(f) ) Reset(f); else Set(f); }
+    MXINLINE bool Is ( T f) const                       { return m_flags&f ? TRUE : FALSE  ; }
+    MXINLINE operator T() const                         { return m_flags; }
     friend MXINLINE archive& operator<<( archive& ar, flags<T>& f )        { return f.Serialize(ar); }
     friend MXINLINE archive& operator>>( archive& ar, flags<T>& f )        { return f.Serialize(ar); }
 private:
@@ -68,6 +69,6 @@ private:
 typedef flags<u64>  flags64;
 typedef flags<u32>  flags32;
 typedef flags<u16>  flags16;
-typedef flags<u8>  flags8;
+typedef flags<u8>   flags8;
 
 #endif /* cflags_h */

--- a/main/midnight/src/tme/baseinc/lomxtypes.h
+++ b/main/midnight/src/tme/baseinc/lomxtypes.h
@@ -846,10 +846,8 @@ namespace tme {
 
             cf_ai               = MXBIT(12),    // character is an AI character
             cf_killed_foe       = MXBIT(13),    // character killed his foe
-            
-            // TODO: Resolve these
-            // Do we need to be backward compatible?
-#if defined(_LOM_)
+            cf_unused1          = MXBIT(14),    //
+            cf_unused2          = MXBIT(15),    //
             cf_resting          = MXBIT(16),    // currently resting
             cf_inbattle         = MXBIT(17),    // currently in battle
             cf_wonbattle        = MXBIT(18),    // just won a battle
@@ -858,18 +856,6 @@ namespace tme {
             cf_followers        = MXBIT(21),    // has followers
             cf_preparesbattle   = MXBIT(22),    // prepares to do battle
             cf_approaching      = MXBIT(23),    // we are approaching a lord (DDR)
-#endif
-#if defined(_DDR_)
-            cf_resting          = MXBIT(14),    // currently resting
-            cf_inbattle         = MXBIT(15),    // currently in battle
-            cf_wonbattle        = MXBIT(16),    // just won a battle
-            cf_tunnel           = MXBIT(17),    // currently in a tunnel (DDR)
-            cf_usedobject       = MXBIT(18),    // has used his special object (DDR)
-            cf_followers        = MXBIT(19),    // has followers
-            cf_preparesbattle   = MXBIT(20),    // prepares to do battle
-            cf_approaching      = MXBIT(21),    // we are approaching a lord (DDR)
-#endif
-            
         };
 
         enum CHARACTERTRAITS {
@@ -971,10 +957,10 @@ namespace tme {
 #define SAVEGAMEHEADER          "MidnightEngineSaveGame"
 
 #if defined(_DDR_)
-    #define SAVEGAMEVERSION     14
+    #define SAVEGAMEVERSION     15
 #endif
 #if defined(_LOM_)
-    #define SAVEGAMEVERSION     14
+    #define SAVEGAMEVERSION     15
 #endif
 
 

--- a/main/midnight/src/tme/scenarios/ddr/ddr_character.cpp
+++ b/main/midnight/src/tme/scenarios/ddr/ddr_character.cpp
@@ -23,6 +23,7 @@
 #include "scenario_ddr.h"
 #include "scenario_ddr_internal.h"
 #include "ddr_processor_battle.h"
+#include "../../utils/savegamemapping.h"
 
 using namespace tme::scenarios ;
 
@@ -64,7 +65,11 @@ namespace tme {
        
             if ( mx->isSavedGame() )
                 ar >> battlelost ;
-            
+
+            // https://github.com/ChilliHugger/The-Lords-Of-Midnight/issues/178
+            if ( tme::mx->SaveGameVersion() < 15 && tme::mx->isSavedGame() ) {
+                flags = utils::UpdateDDRCharacterFlags(flags);
+            }
         }
 
     }

--- a/main/midnight/src/tme/utils/savegamemapping.cpp
+++ b/main/midnight/src/tme/utils/savegamemapping.cpp
@@ -1,0 +1,32 @@
+//
+//  savegamemapping.cpp
+//  tme
+//
+//  Created by Chris Wild on 01/09/2023.
+//
+
+#include "savegamemapping.h"
+
+namespace tme {
+namespace utils {
+
+    //
+    // Old DDR flags in this section were 2 bits shifted down than LOM
+    //
+
+    flags32 UpdateDDRCharacterFlags(flags32 flags)
+    {
+        auto old_mask = OLD_DDR_CHARACTERFLAGS::cf_all ; // 0x003fc000
+                        
+        auto new_mask = cf_unused1 | cf_unused2 |
+                        cf_resting | cf_inbattle | cf_wonbattle | cf_tunnel |
+                        cf_usedobject | cf_followers | cf_preparesbattle | cf_approaching;
+                        
+        auto old_flags = (flags & old_mask) << 2;
+        flags.Reset(new_mask);
+        flags.Set(old_flags);
+        return flags;
+    }
+
+}
+}

--- a/main/midnight/src/tme/utils/savegamemapping.h
+++ b/main/midnight/src/tme/utils/savegamemapping.h
@@ -1,0 +1,34 @@
+//
+//  savegamemapping.h
+//  revenge
+//
+//  Created by Chris Wild on 01/09/2023.
+//
+
+#ifndef savegamemapping_h
+#define savegamemapping_h
+
+#include "../baseinc/tme_internal.h"
+
+namespace tme {
+namespace utils {
+
+    enum OLD_DDR_CHARACTERFLAGS {
+        cf_resting          = MXBIT(14),    // currently resting
+        cf_inbattle         = MXBIT(15),    // currently in battle
+        cf_wonbattle        = MXBIT(16),    // just won a battle
+        cf_tunnel           = MXBIT(17),    // currently in a tunnel (DDR)
+        cf_usedobject       = MXBIT(18),    // has used his special object (DDR)
+        cf_followers        = MXBIT(19),    // has followers
+        cf_preparesbattle   = MXBIT(20),    // prepares to do battle
+        cf_approaching      = MXBIT(21),    // we are approaching a lord (DDR)
+        
+        cf_all              =   cf_resting | cf_inbattle | cf_wonbattle | cf_tunnel |
+                                cf_usedobject | cf_followers | cf_preparesbattle | cf_approaching
+    };
+
+    flags32 UpdateDDRCharacterFlags(flags32 flags);
+}
+}
+
+#endif /* savegamemapping_h */

--- a/main/midnight/tests/savegame/savegamemapper_tests.cpp
+++ b/main/midnight/tests/savegame/savegamemapper_tests.cpp
@@ -1,0 +1,77 @@
+//
+//  savegamemapper_tests.cpp
+//  revenge
+//
+//  Created by Chris Wild on 01/09/2023.
+//
+#include "catch2/catch.hpp"
+#include "../../src/tme/baseinc/tme_internal.h"
+#include "../../src/tme/utils/savegamemapping.h"
+
+using oldflags = tme::utils::OLD_DDR_CHARACTERFLAGS ;
+using newflags = tme::flags::CHARACTERFLAGS ;
+
+TEST_CASE("DDR Flags are remapped")
+{
+    flags32 old_flags(
+        oldflags::cf_resting |
+        oldflags::cf_tunnel |
+        oldflags::cf_approaching
+    );
+    
+    flags32 expected_flags(
+        newflags::cf_resting |
+        newflags::cf_tunnel |
+        newflags::cf_approaching
+    );
+
+    flags32 new_flags = tme::utils::UpdateDDRCharacterFlags(old_flags);
+    
+    REQUIRE (new_flags == expected_flags);
+}
+
+TEST_CASE("DDR All Flags are remapped")
+{
+    flags32 old_flags(
+        oldflags::cf_all
+    );
+    
+    flags32 expected_flags(
+        newflags::cf_resting |
+        newflags::cf_inbattle |
+        newflags::cf_wonbattle |
+        newflags::cf_tunnel |
+        newflags::cf_usedobject |
+        newflags::cf_followers |
+        newflags::cf_preparesbattle |
+        newflags::cf_approaching
+     );
+    
+    flags32 new_flags = tme::utils::UpdateDDRCharacterFlags(old_flags);
+    
+    REQUIRE (new_flags == expected_flags);
+}
+
+
+TEST_CASE("Other Flags are not moved")
+{
+    flags32 old_flags(
+        MXBIT(0) |
+        MXBIT(13) |
+        oldflags::cf_tunnel |
+        MXBIT(24) |
+        MXBIT(31)
+    );
+    
+    flags32 expected_flags(
+        MXBIT(0) |
+        MXBIT(13) |
+        newflags::cf_tunnel |
+        MXBIT(24) |
+        MXBIT(31)
+    );
+    
+    flags32 new_flags = tme::utils::UpdateDDRCharacterFlags(old_flags);
+    
+    REQUIRE (new_flags == expected_flags);
+}


### PR DESCRIPTION
Refactor character flags to align DDR and LOM. Triggered on Savegame version 14 and below.
Added unit test for remapping code.