### PR TITLE
#246 fix crash when recruiting soldiers from depleted stronghold

### DIFF
--- a/main/midnight/Source/tme/scenario/item_stronghold.cpp
+++ b/main/midnight/Source/tme/scenario/item_stronghold.cpp
@@ -156,13 +156,11 @@ s32 mxstronghold::BattleSuccess ( const mxlocinfo& locinfo )
 
 u32 mxstronghold::Remove ( mxrace_t race, mxunit_t type, u32 amount )
 {
-#if defined(_LOM_)
-    if ( OccupyingRace() != race || Type() != type )
-        return 0;
-#endif
-    if ( (TotalTroops()-amount) < MinTroops() )
-        amount = TotalTroops()- MinTroops();
-    totaltroops-= amount;
+    auto result = (s32)(TotalTroops()-amount);
+    if ( result < (s32)MinTroops() )
+        amount = TotalTroops() - MinTroops();
+
+    totaltroops -= amount;
     return amount;
 }
 
@@ -182,10 +180,6 @@ u32 mxstronghold::Remove ( mxrace_t race, mxunit_t type, u32 amount )
 
 u32 mxstronghold::Add ( mxrace_t race, mxunit_t type, u32 amount )
 {
-#if defined(_LOM_)
-    if ( OccupyingRace() != race || Type() != type )
-        return 0;
-#endif
     if ( (TotalTroops()+amount) > MaxTroops() )
         amount = MaxTroops()- TotalTroops();
     totaltroops += amount;
@@ -249,7 +243,7 @@ void mxstronghold::MakeChangeSides( mxrace_t newrace, mxcharacter* newoccupier )
 
 void mxstronghold::CheckForZero ( void )
 {
-    if ( totaltroops <= 0  )
+    if ( (s32)totaltroops <= 0  )
         totaltroops = (u32)sv_stronghold_default_empty;
 }
 

--- a/main/midnight/Source/tme/scenarios/lom/lom_stronghold.cpp
+++ b/main/midnight/Source/tme/scenarios/lom/lom_stronghold.cpp
@@ -21,9 +21,6 @@ using namespace tme::scenarios ;
 
 namespace tme {
     
-//namespace lom {
-
-    
     lom_stronghold::lom_stronghold()
     {
         mxentity::idType = IDT_STRONGHOLD ;
@@ -38,32 +35,20 @@ namespace tme {
 
     }
 
-    /*
-     * Function name    : lom_tronghold::Remove
-     * 
-     * Return type        : int
-     * 
-     * Arguments        : mxrace_t race
-     *                  : mxunit_t type
-     *                  : int amount
-     * 
-     * Description        : 
-     * 
-     */
+    u32 lom_stronghold::Add ( mxrace_t race, mxunit_t type, u32 amount )
+    {
+        if ( OccupyingRace() != race || Type() != type )
+            return 0;
+
+        return mxstronghold::Add(race, type, amount);
+    }
 
     u32 lom_stronghold::Remove ( mxrace_t race, mxunit_t type, u32 amount )
     {
         if ( OccupyingRace() != race || Type() != type )
             return 0;
 
-    // TODO this is a LOM scenario override
-    //    if ( (Total()-amount) < Min() )
-    //        amount = Total()-Min();
-    //
-        totaltroops-= amount;
-        return amount;
+        return mxstronghold::Remove(race, type, amount);
     }
-
-//} // namespace lom_x
-    
+ 
 } // namespace tme

--- a/main/midnight/Source/tme/scenarios/lom/scenario_lom_internal.h
+++ b/main/midnight/Source/tme/scenarios/lom/scenario_lom_internal.h
@@ -50,6 +50,7 @@ namespace tme {
             lom_stronghold();
             virtual ~lom_stronghold();
             virtual u32 Remove ( mxrace_t race, mxunit_t type, u32 total );
+            virtual u32 Add ( mxrace_t race, mxunit_t type, u32 total );
         };
     //}
     

--- a/main/midnight/tests/revenge/steps/battle_steps.cpp
+++ b/main/midnight/tests/revenge/steps/battle_steps.cpp
@@ -6,7 +6,7 @@
 //
 
 #include "battle_steps.h"
-#include "../../../src/tme/scenarios/ddr/ddr_processor_battle.h"
+#include "../../../Source/tme/scenarios/ddr/ddr_processor_battle.h"
 
 static const LPCSTR ch_leader = "CH_CARORMAND";
 static const LPCSTR ch_follower = "CH_GLORTHARG";

--- a/main/midnight/tests/revenge/steps/common_steps.cpp
+++ b/main/midnight/tests/revenge/steps/common_steps.cpp
@@ -9,8 +9,8 @@
 //
 
 #include "common_steps.h"
-#include "../../../src/tme/scenarios/ddr/scenario_ddr_internal.h"
-#include "../../../src/tme/scenarios/ddr/ddr_processor_night.h"
+#include "../../../Source/tme/scenarios/ddr/scenario_ddr_internal.h"
+#include "../../../Source/tme/scenarios/ddr/ddr_processor_night.h"
 
 using namespace std;
 

--- a/main/midnight/tests/revenge/tests/battle_tests.cpp
+++ b/main/midnight/tests/revenge/tests/battle_tests.cpp
@@ -7,7 +7,7 @@
 
 #include "../steps/battle_steps.h"
 #include "../steps/common_steps.h"
-#include "../../../src/tme/scenarios/ddr/ddr_processor_battle.h"
+#include "../../../Source/tme/scenarios/ddr/ddr_processor_battle.h"
 
 // GIVEN a hard game
 // AND a lord has followers

--- a/main/midnight/tests/revenge/tests/character_tests.cpp
+++ b/main/midnight/tests/revenge/tests/character_tests.cpp
@@ -379,6 +379,10 @@ SCENARIO("Characters will consider staying in a battle")
     }
 }
 
+void IsSameLocation( loc_t a, loc_t b) {
+    REQUIRE( a == b );
+}
+
 LPCSTR directions[] = { "NORTH", "NORTHEAST", "EAST", "SOUTHEAST", "SOUTH", "SOUTHWEST", "WEST", "NORTHWEST" };
     
 SCENARIO("Characters will look interesting locations containing a lord loyal to the moonprince")
@@ -435,7 +439,7 @@ SCENARIO("Characters will look interesting locations containing a lord loyal to 
                     THEN("the they should not make the enemy location their target")
                     {
                         REQUIRE( result == false );
-                        REQUIRE( c->targetLocation == mxgridref::INVALID );
+                        IsSameLocation( c->targetLocation, mxgridref::INVALID );
                     }
                 }
             }
@@ -451,7 +455,7 @@ SCENARIO("Characters will look interesting locations containing a lord loyal to 
                     THEN("the they should not make the enemy location their target")
                     {
                         REQUIRE( result == false );
-                        REQUIRE( c->targetLocation == mxgridref::INVALID );
+                        IsSameLocation( c->targetLocation, mxgridref::INVALID );
                     }
                 }
             }
@@ -466,7 +470,7 @@ SCENARIO("Characters will look interesting locations containing a lord loyal to 
                     THEN("the they should not make the enemy location their target")
                     {
                         REQUIRE( result == false );
-                        REQUIRE( c->targetLocation == mxgridref::INVALID );
+                        IsSameLocation( c->targetLocation, mxgridref::INVALID );
                     }
                 }
             }
@@ -609,7 +613,7 @@ SCENARIO("Characters will not look interesting locations", "[new]")
                 THEN("the they should npt make the enemy location their target")
                 {
                     REQUIRE( result == false );
-                    REQUIRE( c->targetLocation == mxgridref::INVALID );
+                    IsSameLocation( c->targetLocation, mxgridref::INVALID );
                 }
             }
         }

--- a/main/midnight/tests/test.cpp
+++ b/main/midnight/tests/test.cpp
@@ -2,7 +2,7 @@
 #include "catch2/catch.hpp"
 
 #include "mocks/mocks.h"
-#include "../Source/cocos.h"
+#include "../Source/axmol_sdk.h"
 
 
 int tests_main(int argc, char *argv[])
@@ -17,7 +17,7 @@ int tests_main(int argc, char *argv[])
     auto path = "/Users/chris/Projects/GitHub/The-Lords-Of-Midnight/main/midnight/Builds/mac-tests-ddr/build/Debug/revenge.app/Contents/Resources";
 #endif
 
-    cocos2d::FileUtils::getInstance()->setDefaultResourceRootPath(path);
+    ax::FileUtils::getInstance()->setDefaultResourceRootPath(path);
     return Catch::Session().run( argc, argv );
 
 }


### PR DESCRIPTION
Stronghold remove function was not validly checking -ve numbers when validating the result of a recruit.